### PR TITLE
Various improvements

### DIFF
--- a/src/main/kotlin/de/joshi/modpackdownloader/Main.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/Main.kt
@@ -1,8 +1,8 @@
 package de.joshi.modpackdownloader
 
 import de.joshi.modpackdownloader.auth.CurseforgeApiKey
-import de.joshi.modpackdownloader.download.FileDownloader
 import de.joshi.modpackdownloader.download.CurseforgeModFetcher
+import de.joshi.modpackdownloader.download.FileDownloader
 import de.joshi.modpackdownloader.overrides.OverridesHandler
 import de.joshi.modpackdownloader.parser.ManifestParser
 import de.joshi.modpackdownloader.readme.ModlistService
@@ -18,7 +18,7 @@ class Main {
     fun run(sourceFile: File, targetDirectory: File, emptyDirectory: Boolean = false) {
         val startTime = Instant.now().toEpochMilli()
         LOGGER.info { "Running ModDownloader from $sourceFile to $targetDirectory" }
-        LOGGER.info { "API Key ${CurseforgeApiKey.getApiKey()} detected" }
+        LOGGER.info { "API Key detected" }
 
         if(emptyDirectory) {
             targetDirectory.deleteRecursively()

--- a/src/main/kotlin/de/joshi/modpackdownloader/download/CurseforgeModFetcher.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/download/CurseforgeModFetcher.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
-import java.lang.RuntimeException
 import java.net.URL
 
 class CurseforgeModFetcher {

--- a/src/main/kotlin/de/joshi/modpackdownloader/download/FileDownloader.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/download/FileDownloader.kt
@@ -4,7 +4,7 @@ import de.joshi.modpackdownloader.auth.CurseforgeApiKey
 import de.joshi.modpackdownloader.http.HttpService
 import mu.KotlinLogging
 import java.io.File
-import java.lang.RuntimeException
+import java.io.IOException
 import java.net.URL
 import java.time.Instant
 
@@ -15,15 +15,17 @@ class FileDownloader {
     )
 
     fun downloadModFiles(targetDirectory: File, downloadUrls: List<URL>) {
-        var filesDownloaded = 0
         val startTime = Instant.now().toEpochMilli()
 
         targetDirectory.mkdirs()
 
-        for(fileUrl in downloadUrls) {
-            filesDownloaded++
-            httpService.downloadFile(fileUrl, targetDirectory)
-            LOGGER.info { "$filesDownloaded out of ${downloadUrls.size} remaining" }
+        for((filesDownloaded, fileUrl) in downloadUrls.withIndex()) {
+            try {
+                httpService.downloadFile(fileUrl, targetDirectory)
+                LOGGER.info { "$filesDownloaded out of ${downloadUrls.size} remaining" }
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
         }
         LOGGER.info("Mod downloads completed, ${downloadUrls.size} files downloaded in ${Instant.now().toEpochMilli() - startTime}ms")
     }

--- a/src/main/kotlin/de/joshi/modpackdownloader/http/HttpService.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/http/HttpService.kt
@@ -1,9 +1,7 @@
 package de.joshi.modpackdownloader.http
 
-import de.joshi.modpackdownloader.auth.CurseforgeApiKey
 import mu.KotlinLogging
 import java.io.File
-import java.lang.RuntimeException
 import java.net.URI
 import java.net.URL
 import java.net.http.HttpClient
@@ -39,7 +37,11 @@ class HttpService(private val apiKey: String) {
             return
         }
 
-        fileUrl.openStream().use {
+        val url = if (fileUrl.toString().contains(" ")) {
+            URL(fileUrl.toString().replace(" ", "%20"))
+        } else fileUrl
+
+        url.openStream().use {
             Files.copy(it, destinationFile, StandardCopyOption.REPLACE_EXISTING)
         }
         LOGGER.info("Saved $fileName to $destinationFile")

--- a/src/main/kotlin/de/joshi/modpackdownloader/overrides/OverridesHandler.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/overrides/OverridesHandler.kt
@@ -2,7 +2,6 @@ package de.joshi.modpackdownloader.overrides
 
 import de.joshi.modpackdownloader.models.ManifestData
 import de.joshi.modpackdownloader.util.getOrCreateSubfolder
-import de.joshi.modpackdownloader.util.getSubfolder
 import mu.KotlinLogging
 import java.io.File
 

--- a/src/main/kotlin/de/joshi/modpackdownloader/parser/ManifestParser.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/parser/ManifestParser.kt
@@ -13,13 +13,18 @@ import java.nio.file.Files
 class ManifestParser {
     private val LOGGER = KotlinLogging.logger { }
 
+    private val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
     fun getManifest(modpackFile: File): ManifestData {
 
         val manifestFile = modpackFile.getSubfolder("manifest.json")
             ?: throw FileNotFoundException("No manifest.json file could be found in $modpackFile")
 
         LOGGER.info("Reading Manifest File from $manifestFile")
-        val manifestData = Json.decodeFromString<ManifestData>(Files.readString(manifestFile.toPath()))
+        val manifestData = json.decodeFromString<ManifestData>(Files.readString(manifestFile.toPath()))
         LOGGER.info("Manifest Info:")
         LOGGER.info("Modpack: ${manifestData.name} ${manifestData.version} by ${manifestData.author.ifBlank { "an unknown author" }}")
         LOGGER.info("Minecraft Version: ${manifestData.minecraft.version}, ModLoader: ${manifestData.minecraft.modLoaders.filter { it.primary }.getOrElse(0) { ModLoaderData("unknown", true) }.id}")

--- a/src/main/kotlin/de/joshi/modpackdownloader/readme/ModlistService.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/readme/ModlistService.kt
@@ -9,8 +9,13 @@ class ModlistService {
 
     fun createModlist(sourceFile: File, targetFile: File, modOverrides: File?) {
 
+        if (!File(sourceFile, "modlist.html").exists()) {
+            LOGGER.warn { "No modlist.html file could be found in $sourceFile" }
+            return
+        }
+
         val lines = Files.readAllLines(File(sourceFile, "modlist.html").toPath())
-        var firstIndex = lines.indexOf("</ul>")
+        val firstIndex = lines.indexOf("</ul>")
         File(modOverrides, "mods").listFiles()?.forEachIndexed { i, file ->
             val modName = file.nameWithoutExtension.replaceFirstChar {it.uppercaseChar()}
             lines.add(

--- a/src/main/kotlin/de/joshi/modpackdownloader/readme/ReadMeService.kt
+++ b/src/main/kotlin/de/joshi/modpackdownloader/readme/ReadMeService.kt
@@ -1,7 +1,6 @@
 package de.joshi.modpackdownloader.readme
 
 import de.joshi.modpackdownloader.models.ManifestData
-import de.joshi.modpackdownloader.models.ReadMeInfo
 import de.joshi.modpackdownloader.util.getOrCreateSubfolder
 import mu.KotlinLogging
 import java.io.File


### PR DESCRIPTION
- [Fixes downloads for mods with whitespaces in the name.](https://github.com/juraj-hrivnak/ModpackDownloader/commit/82371dd5472d8ea81dc48b2dae390a9120c6ae66) For example, Pam's HarvestCraft.

- [Made JSON serialization less strict.](https://github.com/juraj-hrivnak/ModpackDownloader/commit/b464bb200cf44246cb2da8b202ab8ae69ad8d9d2)
  - Unknown keys are now allowed. Ensures compatibility for [pax](https://github.com/froehlichA/pax).
  - Quoted boolean literals, and unquoted string literals are now allowed.
- [Print warning when `modlist.html` is not found instead of throwing an exception.](https://github.com/juraj-hrivnak/ModpackDownloader/commit/fc9d20c14012e19f4f9694b050b9ae76a62cb843)
- [Catch errors when mod download fails.](https://github.com/juraj-hrivnak/ModpackDownloader/commit/613a3b0951bb4f2ed46f091fb34e42fe67ae6cf1)
- [Removed API key logging.](https://github.com/juraj-hrivnak/ModpackDownloader/commit/1db5913498bddab863b6d3e6ea042ee8f13c029b) It probably should not be printed it the log.